### PR TITLE
feat: add EnrollmentToken to AgentReport and RemoteConfigRequest

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -193,6 +193,7 @@ type AgentReport struct {
 	RemoteAssistanceDisabled    bool             `json:"remote_assistance_disabled,omitempty"`
 	Tenant                      string           `json:"tenant,omitempty"`
 	Site                        string           `json:"site,omitempty"`
+	EnrollmentToken             string           `json:"enrollment_token,omitempty"`
 	IsWayland                   bool             `json:"is_wayland,omitempty"`
 	HasRustDesk                 bool             `json:"has_rust_desk,omitempty"`
 	HasRustDeskService          bool             `json:"has_rust_desk_service,omitempty"`


### PR DESCRIPTION
## Summary
- Add `EnrollmentToken` field to `AgentReport` struct for agents to send their enrollment token with reports
- Add `EnrollmentToken` field to `RemoteConfigRequest` struct for token validation during agent configuration requests

## Context
Part of the multi-tenancy feature for secure agent registration. The token is sent by the agent during configuration requests and validated by the worker to assign the agent to the correct tenant and site.
